### PR TITLE
Fixed editor crash in latest build

### DIFF
--- a/game/dota/gameinfo.gi
+++ b/game/dota/gameinfo.gi
@@ -81,7 +81,7 @@
 	{
 		"HasModAppSystems" "1"
 		"Capable64Bit" "1"
-		"UsesScaleform" "0"
+		"UsesScaleform" "1" //Scaleform HAS TO BE 1 otherwise editor crashes.
 		"HasGameUI" "1" // dota uses gameui
 		"GameUIFromClient" "1"  // AND that gameui comes from client.dll
 		"URLName" "dota2"


### PR DESCRIPTION
UsesScaleform was changed to 0, has to be 1 otherwise the dota2cfg.exe crashes.